### PR TITLE
Feat/4 : LoginPage UI 구현

### DIFF
--- a/src/components/Common/BackHeader.tsx
+++ b/src/components/Common/BackHeader.tsx
@@ -1,0 +1,48 @@
+import { ArrowLeft } from 'lucide-react'
+import styled from 'styled-components'
+
+type Props = {
+  title?: string
+}
+
+const HeaderWrapper = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  background: white;
+  position: absolute;
+  top: 0;
+  z-index: 2;
+  width: 100%;
+`
+
+const Content = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+`
+
+const Title = styled.h1`
+  font-size: 16px;
+  font-weight: 600;
+  color: black;
+  flex: 1;
+  text-align: center;
+`
+
+const BackHeader = ({ title }: Props) => {
+  return (
+    <HeaderWrapper>
+      <Content>
+        <button onClick={() => window.history.back()}>
+          <ArrowLeft size={24} color={'#000000'} />
+        </button>
+        {title && <Title>{title}</Title>}
+      </Content>
+    </HeaderWrapper>
+  )
+}
+
+export default BackHeader

--- a/src/components/Common/BackHeader.tsx
+++ b/src/components/Common/BackHeader.tsx
@@ -25,7 +25,7 @@ const Content = styled.div`
 `
 
 const Title = styled.h1`
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 600;
   color: black;
   flex: 1;

--- a/src/components/Common/BackHeader.tsx
+++ b/src/components/Common/BackHeader.tsx
@@ -17,30 +17,36 @@ const HeaderWrapper = styled.header`
   width: 100%;
 `
 
-const Content = styled.div`
+const Side = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 100%;
+  width: 24px;
+`
+const BackButton = styled.button`
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  margin-right: 16px;
 `
 
 const Title = styled.h1`
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 600;
   color: black;
-  flex: 1;
   text-align: center;
 `
 
 const BackHeader = ({ title }: Props) => {
   return (
     <HeaderWrapper>
-      <Content>
-        <button onClick={() => window.history.back()}>
+      <Side>
+        <BackButton onClick={() => window.history.back()}>
           <ArrowLeft size={24} color={'#000000'} />
-        </button>
-        {title && <Title>{title}</Title>}
-      </Content>
+        </BackButton>
+      </Side>
+      {title && <Title>{title}</Title>}
+      <Side /> {/*오른쪽 공간 확보*/}
     </HeaderWrapper>
   )
 }

--- a/src/components/LoginPage/LoginBox.tsx
+++ b/src/components/LoginPage/LoginBox.tsx
@@ -1,0 +1,74 @@
+import styled from 'styled-components'
+
+const LoginBoxWrapper = styled.div`
+  padding: 12px 16px;
+  border: 1px solid #073b7b;
+  border-radius: 12px;
+  width: calc(100% - 32px);
+`
+
+const Title = styled.h2`
+  text-align: center;
+  font-size: 16px;
+  font-weight: 600;
+`
+
+const SubText = styled.p`
+  text-align: center;
+  font-size: clamp(12px, 2.5vw, 14px); //최소12px 최대 14px
+  margin-bottom: 10px;
+  white-space: nowrap;
+`
+
+const Input = styled.input`
+  width: 100%;
+  height: 40px;
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  padding: 0 12px;
+  margin-bottom: 16px;
+  background-color: #eeeeee;
+`
+
+const BottomRow = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+const LoginButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 50%;
+  height: 40px;
+  background-color: #073b7b;
+  color: white;
+  font-weight: 600;
+  border-radius: 20px;
+  margin: 10px auto 0;
+`
+
+const LogoutText = styled.button`
+  font-size: 12px;
+  color: black;
+  margin-left: auto;
+  text-decoration: underline;
+`
+
+export default function LoginBox() {
+  return (
+    <LoginBoxWrapper>
+      <Title>인천대 구성원</Title>
+      <SubText>학교 포탈 아이디로 별도의 회원가입 없이 바로 로그인하세요!</SubText>
+
+      <Input type="text" placeholder="ID" />
+      <Input type="password" placeholder="Password" />
+
+      <BottomRow>
+        <LogoutText>로그아웃</LogoutText>
+      </BottomRow>
+
+      <LoginButton>로그인</LoginButton>
+    </LoginBoxWrapper>
+  )
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+
+import BackHeader from '../components/Common/BackHeader.tsx'
+import BottomNavBar from '../components/Common/BottomNavBar.tsx'
+import { useViewportVH } from '../hooks/useViewportVH'
+
+const LoginPageWrapper = styled.div`
+  background: white;
+`
+const HeaderWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`
+
+const LoginPage = () => {
+  useViewportVH()
+  const [tab, setTab] = useState<'find' | 'map' | 'me'>('find')
+
+  return (
+    <LoginPageWrapper className="app">
+      <HeaderWrapper>
+        <BackHeader title="로그인/회원가입" />
+      </HeaderWrapper>
+      <div className={'bottom-gap'} />
+      <BottomNavBar activeKey={tab} onChange={(key) => setTab(key as 'find' | 'map' | 'me')} />
+    </LoginPageWrapper>
+  )
+}
+
+export default LoginPage

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import BackHeader from '../components/Common/BackHeader.tsx'
 import BottomNavBar from '../components/Common/BottomNavBar.tsx'
+import LoginBox from '../components/LoginPage/LoginBox.tsx'
 import { useViewportVH } from '../hooks/useViewportVH'
 
 const LoginPageWrapper = styled.div`
@@ -12,6 +13,12 @@ const HeaderWrapper = styled.div`
   position: relative;
   width: 100%;
 `
+const Content = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+`
 
 const LoginPage = () => {
   useViewportVH()
@@ -19,9 +26,12 @@ const LoginPage = () => {
 
   return (
     <LoginPageWrapper className="app">
-      <HeaderWrapper>
+      <HeaderWrapper className={'sticky-top'}>
         <BackHeader title="로그인/회원가입" />
       </HeaderWrapper>
+      <Content className="app-content">
+        <LoginBox />
+      </Content>
       <div className={'bottom-gap'} />
       <BottomNavBar activeKey={tab} onChange={(key) => setTab(key as 'find' | 'map' | 'me')} />
     </LoginPageWrapper>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Closes #5

## 📝 작업 내용
- LoginPage UI 퍼블리싱 완료
- 기존 디자인에서 일부 조정 
 - 뒤로가기 버튼 + 타이틀 한줄로 구성 (재사용을 위해서)
 - 사진등록하기 제거 

## 스크린샷 (선택)
<img width="432" height="764" alt="image" src="https://github.com/user-attachments/assets/e9567cd3-790a-4c80-b9ca-9cd610ee5a79" />
