### PR TITLE
feat : 마이페이지 조건부 렌더링 및 로그아웃 항목 추가 (#40)

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,32 +1,48 @@
 import { ChevronRight } from 'lucide-react'
 import { Link } from 'react-router-dom'
+import { useAuth } from '@/hooks/useAuth'
+import { useAuthContext } from '@/hooks/useAuthContext'
 import styled from 'styled-components'
 
 export default function MyPage() {
+  const { isAuthenticated } = useAuthContext()
+  const { logout } = useAuth()
   return (
     <Wrap>
       <Content>
         <Title>My Page</Title>
 
         <Card>
-          <Row to="/login">
-            <Left>로그인 / 회원가입</Left>
-            <Right>
-              <ChevronRight size={24} />
-            </Right>
-          </Row>
-          <Row to="/reviews/history">
-            <Left>작성 후기 수정 / 최근 기록</Left>
-            <Right>
-              <ChevronRight size={24} />
-            </Right>
-          </Row>
-          <Row to="/profile">
-            <Left>프로필 수정 및 회원탈퇴</Left>
-            <Right>
-              <ChevronRight size={24} />
-            </Right>
-          </Row>
+          {!isAuthenticated && (
+            <Row to="/login">
+              <Left>로그인 / 회원가입</Left>
+              <Right>
+                <ChevronRight size={24} />
+              </Right>
+            </Row>
+          )}
+          {isAuthenticated && (
+            <>
+              <Row to="/reviews/history">
+                <Left>작성 후기 수정 / 최근 기록</Left>
+                <Right>
+                  <ChevronRight size={24} />
+                </Right>
+              </Row>
+              <Row to="/profile">
+                <Left>프로필 수정 및 회원탈퇴</Left>
+                <Right>
+                  <ChevronRight size={24} />
+                </Right>
+              </Row>
+              <Row to="/" onClick={logout}>
+                <Left>로그아웃</Left>
+                <Right>
+                  <ChevronRight size={24} />
+                </Right>
+              </Row>
+            </>
+          )}
         </Card>
       </Content>
     </Wrap>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #40 

## 📝 작업 내용

> 마이페이지 조건부 렌더링 + 로그아웃 컴포넌트 추가

### 스크린샷 (선택)
- 로그인을 안하면 ? -> 로그인 / 회원가입 컴포넌트만 살리기
<img width="850" height="1760" alt="image" src="https://github.com/user-attachments/assets/f492bf53-04da-45ca-80e2-c75d546002c7" />

- 로그인을 하면? -> 로그인 권한에서만 접근 가능한 컴포넌트 살리기
<img width="858" height="1770" alt="image" src="https://github.com/user-attachments/assets/42ef38fb-9548-4e70-ba10-ef653d8fed39" />

