### PR TITLE
refactor : 컴포넌트 export를 화살표 함수 + 분리 default로 통일 (#47)

### DIFF
--- a/src/components/Common/ToastContainer.tsx
+++ b/src/components/Common/ToastContainer.tsx
@@ -29,7 +29,7 @@ const Item = styled.div<{ type: 'success' | 'error' | 'info' }>`
   pointer-events: auto;
 `
 
-export default function ToastContainer() {
+const ToastContainer = () => {
   const toasts = useToastStore((s) => s.toasts)
 
   if (!toasts.length) return null
@@ -44,3 +44,4 @@ export default function ToastContainer() {
   )
 }
 
+export default ToastContainer

--- a/src/components/LoginPage/LoginBox.tsx
+++ b/src/components/LoginPage/LoginBox.tsx
@@ -60,7 +60,7 @@ const LogoutText = styled.button`
   text-decoration: underline;
 `
 
-export default function LoginBox() {
+const LoginBox = () => {
   const [studentNumber, setStudentNumber] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
@@ -123,3 +123,5 @@ export default function LoginBox() {
     </LoginBoxWrapper>
   )
 }
+
+export default LoginBox

--- a/src/components/MainPage/PlaceList.tsx
+++ b/src/components/MainPage/PlaceList.tsx
@@ -28,7 +28,7 @@ type Props = {
   filter?: string | ''
 }
 
-export default function PlaceList({ onCardClick, filter = '' }: Props) {
+const PlaceList = ({ onCardClick, filter = '' }: Props) => {
   const { list, loading, hasNext, loadMore } = usePlaces(8, filter)
 
   // 최신 상태를 보게 하고, 로딩/마지막 페이지 때는 관찰 잠깐 중지
@@ -56,3 +56,5 @@ export default function PlaceList({ onCardClick, filter = '' }: Props) {
     </>
   )
 }
+
+export default PlaceList

--- a/src/components/MyCampusMap/MapBottomSheet.tsx
+++ b/src/components/MyCampusMap/MapBottomSheet.tsx
@@ -105,13 +105,13 @@ const PrimaryBtn = styled.button`
   font-size: 15px;
 `
 
-export default function MapBottomSheet({
+const MapBottomSheet = ({
   isOpen,
   onClose,
   place,
   onClickPrimary,
   primaryLabel = '자세히 보기',
-}: Props) {
+}: Props) => {
   const visible = useMemo(() => isOpen && !!place, [isOpen, place])
 
   useEffect(() => {
@@ -154,3 +154,5 @@ export default function MapBottomSheet({
     </>
   )
 }
+
+export default MapBottomSheet

--- a/src/components/PlaceDetails/ReviewButton.tsx
+++ b/src/components/PlaceDetails/ReviewButton.tsx
@@ -14,6 +14,8 @@ type Props = {
   onClickReview: () => void
 }
 
-export default function ReviewButton({ isLogin, onClickLogin, onClickReview }: Props) {
+const ReviewButton = ({ isLogin, onClickLogin, onClickReview }: Props) => {
   return <Button onClick={isLogin ? onClickReview : onClickLogin}>이용후기 등록</Button>
 }
+
+export default ReviewButton

--- a/src/components/PlaceReview/Btns/BackBtn.tsx
+++ b/src/components/PlaceReview/Btns/BackBtn.tsx
@@ -6,7 +6,7 @@ type Props = {
   onClick?: () => void
 }
 
-export default function BackButton({ onClick }: Props) {
+const BackButton = ({ onClick }: Props) => {
   const navigate = useNavigate()
 
   const handleClick = () => {
@@ -23,6 +23,8 @@ export default function BackButton({ onClick }: Props) {
     </Button>
   )
 }
+
+export default BackButton
 
 const Button = styled.button`
   position: absolute;

--- a/src/components/PlaceReview/Btns/CloseBtn.tsx
+++ b/src/components/PlaceReview/Btns/CloseBtn.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 type Props = { onClose?: () => void }
 
-export default function CloseHeader({ onClose }: Props) {
+const CloseHeader = ({ onClose }: Props) => {
   return (
     <HeaderOuter>
       {' '}
@@ -16,6 +16,8 @@ export default function CloseHeader({ onClose }: Props) {
     </HeaderOuter>
   )
 }
+
+export default CloseHeader
 
 const HeaderOuter = styled.header`
   flex: 0 0 auto;

--- a/src/components/PlaceReview/Btns/NextBtn.tsx
+++ b/src/components/PlaceReview/Btns/NextBtn.tsx
@@ -7,7 +7,7 @@ type Props = {
   onClick: () => void
 }
 
-export default function NextBtn({ label = '다음', disabled, onClick }: Props) {
+const NextBtn = ({ label = '다음', disabled, onClick }: Props) => {
   return (
     <Bar>
       <Button disabled={disabled} onClick={onClick}>
@@ -16,6 +16,8 @@ export default function NextBtn({ label = '다음', disabled, onClick }: Props) 
     </Bar>
   )
 }
+
+export default NextBtn
 
 const Bar = styled.div`
   position: fixed;

--- a/src/components/PlaceReview/Btns/PrevNextBtn.tsx
+++ b/src/components/PlaceReview/Btns/PrevNextBtn.tsx
@@ -12,7 +12,7 @@ type Props = {
   className?: string
 }
 
-export default function PrevNextBtn({
+const PrevNextBtn = ({
   onPrev,
   onNext,
   prevLabel = '이전',
@@ -21,7 +21,7 @@ export default function PrevNextBtn({
   fixed = true,
   bottom,
   className,
-}: Props) {
+}: Props) => {
   return (
     <Bar $fixed={fixed} $bottom={bottom} className={className}>
       <Buttons>
@@ -37,6 +37,8 @@ export default function PrevNextBtn({
     </Bar>
   )
 }
+
+export default PrevNextBtn
 
 const Bar = styled.div<{ $fixed?: boolean; $bottom?: string }>`
   position: ${({ $fixed }) => ($fixed ? 'fixed' : 'static')};

--- a/src/components/PlaceReview/CommentCard/CommentCard.tsx
+++ b/src/components/PlaceReview/CommentCard/CommentCard.tsx
@@ -8,7 +8,7 @@ type Props = {
   imagePosition?: 'left' | 'right'
 }
 
-export default function CommentCard({ text = '', imageUrls = [], imagePosition = 'left' }: Props) {
+const CommentCard = ({ text = '', imageUrls = [], imagePosition = 'left' }: Props) => {
   const first = imageUrls[0]
   const moreCount = imageUrls.length > 1 ? imageUrls.length - 1 : 0
   const reverse = imagePosition === 'right'
@@ -32,6 +32,8 @@ export default function CommentCard({ text = '', imageUrls = [], imagePosition =
     </Card>
   )
 }
+
+export default CommentCard
 
 const Card = styled.div`
   padding: 12px;

--- a/src/components/PlaceReview/DateTimeSelector.tsx
+++ b/src/components/PlaceReview/DateTimeSelector.tsx
@@ -20,12 +20,12 @@ function formatKoreanDate(d: Date) {
   return `${yy}년 ${m}월 ${day}일 ${weekday}`
 }
 
-export default function DateTimeSelector({
+const DateTimeSelector = ({
   valueDate: controlledDate,
   valueTime: controlledTime,
   onChangeDate,
   onChangeTime,
-}: DateTimeSelectorProps) {
+}: DateTimeSelectorProps) => {
   const [date, setDate] = useState<Date | null>(controlledDate ?? null)
   const [time, setTime] = useState<{ hour: number; minute: number } | null>(controlledTime ?? null)
 
@@ -146,6 +146,8 @@ export default function DateTimeSelector({
     </Wrap>
   )
 }
+
+export default DateTimeSelector
 
 function to2(n: number) {
   return n.toString().padStart(2, '0')

--- a/src/components/PlaceReview/PlaceCard.tsx
+++ b/src/components/PlaceReview/PlaceCard.tsx
@@ -9,13 +9,13 @@ type PlaceCardProps = {
   imgHeight?: number // 기본 190
 }
 
-export default function PlaceCard({
+const PlaceCard = ({
   buildingText,
   placeName,
   guideText = '방문 일시를 확인해 주세요!',
   images,
   imgHeight = 140,
-}: PlaceCardProps) {
+}: PlaceCardProps) => {
   const [index, setIndex] = useState(0)
   const scrollerRef = useRef<HTMLDivElement>(null)
 
@@ -82,6 +82,8 @@ export default function PlaceCard({
     </Card>
   )
 }
+
+export default PlaceCard
 
 const Group = styled.div`
   position: relative;

--- a/src/components/PlaceReview/ReviewKeywordSelector.tsx
+++ b/src/components/PlaceReview/ReviewKeywordSelector.tsx
@@ -35,7 +35,7 @@ const DEFAULT_GROUPS: Group[] = [
   },
 ]
 
-export default function ReviewKeywordSelector({
+const ReviewKeywordSelector = ({
   selected,
   onChange,
   noKeyword,
@@ -44,7 +44,7 @@ export default function ReviewKeywordSelector({
   maxPick = 3,
   groups = DEFAULT_GROUPS,
   valueKey = 'id',
-}: Props) {
+}: Props) => {
   const toggleByValue = (val: string) => {
     if (noKeyword) return
     const next = new Set(selected)
@@ -124,6 +124,8 @@ export default function ReviewKeywordSelector({
     </Wrap>
   )
 }
+
+export default ReviewKeywordSelector
 
 const Wrap = styled.section`
   border-radius: 12px;

--- a/src/components/PlaceReview/ReviewRequest/ReviewInput.tsx
+++ b/src/components/PlaceReview/ReviewRequest/ReviewInput.tsx
@@ -132,7 +132,7 @@ const Counter = styled.div<{ $danger?: boolean }>`
   color: ${({ $danger }) => ($danger ? '#a6363aff' : '#8a94a6')};
 `
 
-export default function ReviewInput({ photos, comment, maxLength = 400, onChange }: Props) {
+const ReviewInput = ({ photos, comment, maxLength = 400, onChange }: Props) => {
   const fileRef = useRef<HTMLInputElement>(null)
 
   // 파일 선택 트리거
@@ -237,3 +237,5 @@ export default function ReviewInput({ photos, comment, maxLength = 400, onChange
     </Wrap>
   )
 }
+
+export default ReviewInput

--- a/src/components/PlaceReview/ReviewRequest/VisitHistory.tsx
+++ b/src/components/PlaceReview/ReviewRequest/VisitHistory.tsx
@@ -78,13 +78,13 @@ function formatDate(isoOrDate?: string | Date) {
   return `${y}.${m}.${day}.(${week})`
 }
 
-export default function VisitHistory({
+const VisitHistory = ({
   placeName,
   visitAt,
   visitCount,
   keywords,
   noKeyword,
-}: Props) {
+}: Props) => {
   const dateText = formatDate(visitAt)
 
   return (
@@ -111,3 +111,5 @@ export default function VisitHistory({
     </Wrap>
   )
 }
+
+export default VisitHistory

--- a/src/components/PlaceReview/VisitComplete/PlaceTitle.tsx
+++ b/src/components/PlaceReview/VisitComplete/PlaceTitle.tsx
@@ -10,13 +10,13 @@ type Props = {
   hideLabel?: boolean
 }
 
-export default function PlaceTitle({
+const PlaceTitle = ({
   label = '[공간 이름]',
   buildingText = '00호관 00층 00호',
   onToggleFavorite,
   rightSlot,
   hideLabel = false,
-}: Props) {
+}: Props) => {
   return (
     <Wrap>
       <Left>
@@ -30,6 +30,8 @@ export default function PlaceTitle({
     </Wrap>
   )
 }
+
+export default PlaceTitle
 
 const Wrap = styled.div`
   display: flex;

--- a/src/components/PlaceReview/VisitComplete/PrimaryButton.tsx
+++ b/src/components/PlaceReview/VisitComplete/PrimaryButton.tsx
@@ -8,7 +8,7 @@ type Props = {
   disabled?: boolean // 비활성화 여부
 }
 
-export default function PrimaryButton({ label, onClick, disabled }: Props) {
+const PrimaryButton = ({ label, onClick, disabled }: Props) => {
   return (
     <Btn type="button" onClick={onClick} disabled={disabled}>
       <PencilLine size={18} strokeWidth={2} />
@@ -16,6 +16,8 @@ export default function PrimaryButton({ label, onClick, disabled }: Props) {
     </Btn>
   )
 }
+
+export default PrimaryButton
 
 const Btn = styled.button`
   width: 93%;

--- a/src/components/PlaceReview/VisitComplete/PrivateTip.tsx
+++ b/src/components/PlaceReview/VisitComplete/PrivateTip.tsx
@@ -7,7 +7,7 @@ type Props = {
   defaultOpen?: boolean
 }
 
-export default function PrivateTip({ defaultOpen = true }: Props) {
+const PrivateTip = ({ defaultOpen = true }: Props) => {
   const [open, setOpen] = useState(defaultOpen)
 
   if (!open) return null
@@ -24,6 +24,8 @@ export default function PrivateTip({ defaultOpen = true }: Props) {
     </Wrap>
   )
 }
+
+export default PrivateTip
 
 const Wrap = styled.div`
   height: 54px;

--- a/src/components/PlaceReview/VisitComplete/VisitMetaRow.tsx
+++ b/src/components/PlaceReview/VisitComplete/VisitMetaRow.tsx
@@ -10,7 +10,7 @@ type Props = {
   onDelete?: () => void
 }
 
-export default function VisitMetaRow({ dateText, timeText, countText, onDelete }: Props) {
+const VisitMetaRow = ({ dateText, timeText, countText, onDelete }: Props) => {
   return (
     <Wrap>
       <Left>
@@ -29,6 +29,8 @@ export default function VisitMetaRow({ dateText, timeText, countText, onDelete }
     </Wrap>
   )
 }
+
+export default VisitMetaRow
 
 const Wrap = styled.div`
   display: flex;

--- a/src/components/PlaceReview/WheelDateTimePicker.tsx
+++ b/src/components/PlaceReview/WheelDateTimePicker.tsx
@@ -17,7 +17,7 @@ type Props = {
   onConfirmTime?: (t: TimeVal) => void
 }
 
-export default function WheelDateTimePicker({
+const WheelDateTimePicker = ({
   open,
   mode,
   initialDate = new Date(),
@@ -25,7 +25,7 @@ export default function WheelDateTimePicker({
   onClose,
   onConfirmDate,
   onConfirmTime,
-}: Props) {
+}: Props) => {
   const [year, setYear] = useState(initialDate.getFullYear())
   const [month, setMonth] = useState(initialDate.getMonth() + 1) // 1~12
   const [day, setDay] = useState(initialDate.getDate())
@@ -105,6 +105,8 @@ export default function WheelDateTimePicker({
     </Dim>
   )
 }
+
+export default WheelDateTimePicker
 
 function WheelColumn<T extends number | string>({
   values,

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,10 +1,11 @@
 import { ChevronRight } from 'lucide-react'
 import { Link } from 'react-router-dom'
-import { useAuthStore } from '@/stores/authStore'
-import { useAuth } from '@/hooks/useAuth'
 import styled from 'styled-components'
 
-export default function MyPage() {
+import { useAuth } from '@/hooks/useAuth'
+import { useAuthStore } from '@/stores/authStore'
+
+const MyPage = () => {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const { logout } = useAuth()
   return (
@@ -48,6 +49,8 @@ export default function MyPage() {
     </Wrap>
   )
 }
+
+export default MyPage
 
 const Wrap = styled.main`
   --gutter: 16px;

--- a/src/pages/SelectPost.tsx
+++ b/src/pages/SelectPost.tsx
@@ -7,7 +7,7 @@ type Props = {
   hasPermission: boolean
 }
 
-export default function SelectPost({ hasPermission }: Props) {
+const SelectPost = ({ hasPermission }: Props) => {
   return (
     <Page>
       <BackHeader title="사진 불러오기 (최근 항목)" />
@@ -32,6 +32,8 @@ export default function SelectPost({ hasPermission }: Props) {
     </Page>
   )
 }
+
+export default SelectPost
 
 const Page = styled.div`
   min-height: 100svh;

--- a/src/pages/VisitCompletePage.tsx
+++ b/src/pages/VisitCompletePage.tsx
@@ -27,7 +27,7 @@ type VisitCompleteState = {
   comment?: string
 }
 
-export default function VisitCompletePage() {
+const VisitCompletePage = () => {
   const navigate = useNavigate()
   const nav = useNavigate()
   const { state } = useLocation() as { state?: VisitCompleteState }
@@ -196,6 +196,8 @@ export default function VisitCompletePage() {
     </Viewport>
   )
 }
+
+export default VisitCompletePage
 
 const BackWrap = styled.div`
   position: absolute;

--- a/src/tests/insertPlace.tsx
+++ b/src/tests/insertPlace.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from 'react'
 const toBool = (s: string) => /^(true|1|y|yes)$/i.test(String(s).trim())
 const withBearer = (t: string) => (t ? (t.startsWith('Bearer ') ? t : `Bearer ${t}`) : '')
 
-export default function InsertPlaceMini() {
+const InsertPlaceMini = () => {
   const [baseUrl, setBaseUrl] = useState(
     import.meta.env.VITE_API_BASE_URL ?? 'https://spotinu-server.inuappcenter.kr',
   )
@@ -316,3 +316,5 @@ export default function InsertPlaceMini() {
     </div>
   )
 }
+
+export default InsertPlaceMini


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #47

## 📝 작업 내용

> 몇몇 페이지가 컨벤션에 맞지 않는 형태로 작업되어있어, 표현식의 형태로 수정해주었음.
