### PR TITLE
feat: integrate spot list API with distance sorting

### DIFF
--- a/src/components/MainPage/PlaceCard.tsx
+++ b/src/components/MainPage/PlaceCard.tsx
@@ -1,18 +1,9 @@
 import { Building2, MapPin, Users } from 'lucide-react'
 import styled from 'styled-components'
 
-export type Place = {
-  id: string
-  title: string
-  subtitle: string
-  building: string
-  distanceText: string
-  imageUrl: string
-  typeText?: string
-  tags?: string[]
-}
+import type { PlaceSummary } from '@/types/PlaceSummaryType'
 
-type Props = { place: Place; onClick?: (id: string) => void }
+type Props = { place: PlaceSummary; onClick?: (id: string) => void }
 
 const Card = styled.article`
   background: #fff;
@@ -37,12 +28,11 @@ const Body = styled.div`
   gap: 12px;
 `
 
-/* 첫 줄: 제목 좌 / 설명 우 */
+/* 첫 줄: 제목 아래 설명 */
 const TopRow = styled.div`
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
+  flex-direction: column;
+  gap: 4px;
 `
 const Title = styled.h3`
   margin: 0;
@@ -53,9 +43,8 @@ const Title = styled.h3`
 const Subtitle = styled.p`
   margin: 0;
   font-size: 14px;
-  color: #6b7280;
-  text-align: right;
-  flex-shrink: 0;
+  color: #4b5563;
+  line-height: 1.4;
 `
 
 /* 두 번째 줄: 건물/층 정보 */
@@ -93,7 +82,7 @@ const DistanceInfo = styled.div`
 const PlaceCard = ({ place, onClick }: Props) => {
   return (
     <Card onClick={() => onClick?.(place.id)}>
-      <Image src={place.imageUrl} alt={place.title} />
+      <Image src={place.imageUrl} alt={place.title} loading="lazy" />
 
       <Body>
         <TopRow>
@@ -109,7 +98,7 @@ const PlaceCard = ({ place, onClick }: Props) => {
         <BottomRow>
           <TypeInfo>
             <Users size={16} />
-            <span>{place.typeText}</span>
+            <span>{place.typeText ?? '정보 없음'}</span>
           </TypeInfo>
           <DistanceInfo>
             <MapPin size={16} />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -38,7 +38,7 @@ const MainPage = () => {
       </StickyWrap>
 
       <Content className="app-content">
-        <PlaceList filter={filter} onCardClick={() => navigate(`/places/2`)} />
+        <PlaceList filter={filter} onCardClick={(id) => navigate(`/places/${id}`)} />
       </Content>
     </main>
   )

--- a/src/types/PlaceSummaryType.ts
+++ b/src/types/PlaceSummaryType.ts
@@ -1,0 +1,12 @@
+export interface PlaceSummary {
+  id: string
+  title: string
+  subtitle: string
+  building: string
+  distanceText: string
+  imageUrl: string
+  typeText?: string
+  tags: string[]
+  latitude: number | null
+  longitude: number | null
+}

--- a/src/utils/placeSummary.ts
+++ b/src/utils/placeSummary.ts
@@ -1,0 +1,66 @@
+export type PlaceFeatureFlags = {
+  sleepingAllowed: boolean
+  eatingAllowed: boolean
+  hasPowerOutlet: boolean
+  studyAllowed: boolean
+  entertainment: boolean
+  reservationRequired: boolean
+  placeType: string
+}
+
+type FeatureKey = keyof Omit<PlaceFeatureFlags, 'placeType'>
+
+const FEATURE_LABELS: Record<FeatureKey, string> = {
+  sleepingAllowed: '취침',
+  eatingAllowed: '취식',
+  hasPowerOutlet: '콘센트',
+  studyAllowed: '개인공부',
+  entertainment: '오락시설',
+  reservationRequired: '예약제',
+}
+
+export const derivePlaceTags = (flags: PlaceFeatureFlags): string[] => {
+  const tags: string[] = []
+
+  const entries = Object.entries(FEATURE_LABELS) as [FeatureKey, string][]
+  entries.forEach(([key, label]) => {
+    if (flags[key]) tags.push(label)
+  })
+
+  const type = flags.placeType?.toUpperCase()
+  if (type === 'OUTDOOR') tags.push('야외')
+
+  return tags
+}
+
+export const calculateDistanceInMeters = (
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number => {
+  const toRad = (deg: number) => (deg * Math.PI) / 180
+  const R = 6371e3 // 지구 반경 (m)
+
+  const phi1 = toRad(lat1)
+  const phi2 = toRad(lat2)
+  const deltaPhi = toRad(lat2 - lat1)
+  const deltaLambda = toRad(lon2 - lon1)
+
+  const a =
+    Math.sin(deltaPhi / 2) ** 2 +
+    Math.cos(phi1) * Math.cos(phi2) * Math.sin(deltaLambda / 2) ** 2
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+
+  return R * c
+}
+
+export const formatDistanceText = (distanceInMeters: number | null | undefined): string => {
+  if (distanceInMeters == null || !Number.isFinite(distanceInMeters)) return '거리 정보 없음'
+
+  if (distanceInMeters < 1000) return `약 ${Math.round(distanceInMeters)}m`
+
+  const km = distanceInMeters / 1000
+  const display = km < 10 ? km.toFixed(1) : Math.round(km).toString()
+  return `약 ${display}km`
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #50 

## 📝 작업 내용

- [x] 더미 대신 /spots 호출로 실제 데이터를 수집하고, 모든 페이지를 순회해 모은 뒤 현재 위치 좌표로 거리 계산·정렬

- [x] feature 플래그→태그 변환, 하버사인 거리 계산, 표시 문자열을 src/utils/placeSummary.ts로 분리했고, 카드/훅 간에 공유할 PlaceSummary 타입을 신설 (PlaceSummaryType.ts).

- [x] distanceText haversine Algorithm을 반영하여 위도-경도를 기반으로 좌표계산하여 표기

- [x] 계산된 거리는 오름차순으로 정렬되도록 구현

- [x] API로 받은 장소 타입(필터 유형)을 기준으로 필터링하는거 구현

### 스크린샷 (거리별로 오름차순 정렬
<img width="387" height="838" alt="image" src="https://github.com/user-attachments/assets/d702d2a8-b9df-484d-84ad-198f4df60842" />
