### PR TITLE
fix : 배너 이미지 viewport frame에 fit하게 수정

### DIFF
--- a/src/components/MainPage/Banner.tsx
+++ b/src/components/MainPage/Banner.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components'
 
-const Root = styled.section<{ $h: number }>`
+const Root = styled.section`
   position: relative;
-  height: ${({ $h }) => $h}px;
+  width: 100vw;
+  height: clamp(180px, 56vw, 260px);
 
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
-  width: 100vw;
   overflow: hidden;
 
   &::before {
@@ -43,7 +43,7 @@ const Slide = styled.div`
 const Img = styled.img`
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: fill;
   display: block;
 `
 
@@ -68,7 +68,7 @@ const Banner = () => {
   const images = ['/Banner/Banner1.png', '/Banner/Banner2.png', '/Banner/Banner3.png']
 
   return (
-    <Root $h={200}>
+    <Root>
       <Viewport>
         {images.map((src, i) => (
           <Slide key={i}>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #51

## 📝 작업 내용

- [x] object-fit : fill로 배너 이미지 통일
- [x] 배너 이미지를 동일 뷰포트 프레임에 맞추기

### 스크린샷 
<img width="494" height="231" alt="image" src="https://github.com/user-attachments/assets/4407b467-02c6-40c1-84f0-4dedccbfa25f" />
